### PR TITLE
Update for Xcode 14.1+

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.0'
 
 target 'Quickstart' do
   # Comment the next line if you don't want to use dynamic frameworks


### PR DESCRIPTION
### Background
Apple announced that starting April 25, 2023, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 14.1 or later(https://developer.apple.com/news/?id=jd9wcyov ).
It should be verified that all iOS SampleApps in Sendbird run on Xcode14.1+.

### Summary
 - [Change the ios version(9.0 -> 11.0) of Podfile](https://github.com/sendbird/quickstart-desk-ios/commit/a8937641b2b202bba7692ef830545965caf95684)

### Further Comments
