### PR TITLE
Added a new feature: Send confirmation of ticket closing

### DIFF
--- a/QuickStart/AppDelegate.swift
+++ b/QuickStart/AppDelegate.swift
@@ -27,6 +27,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set up queue for delegates
         SBDSKMain.setCompletionHandlerDelegateQueue(.main)
         
+        // Disable unused string set
+        SBUStringSet.Message_Edited = ""
         return true
     }
 }

--- a/QuickStart/ChatViewController.swift
+++ b/QuickStart/ChatViewController.swift
@@ -44,7 +44,11 @@ extension ChatViewController: DeskChannelModuleListDelegate {
         self.present(alertController, animated: true)
     }
     
-    /// [Documentations | Send confirmation of ticket closing]( https://sendbird.com/docs/desk/sdk/v1/ios/features/confirmation-request#2-send-confirmation-of-ticket-closing)
+    /// Send confirmation of ticket closing and send user message when the completion block is called.
+    ///
+    /// When `confirmed` is true, it sends user message with the text saying "Yes". If it's `false`, sends the text saying "No".
+    ///
+    /// - NOTE: [Documentations | Send confirmation of ticket closing]( https://sendbird.com/docs/desk/sdk/v1/ios/features/confirmation-request#2-send-confirmation-of-ticket-closing)
     func sendConfirmation(_ confirmed: Bool, toInquireMessage message: UserMessage) {
         SBDSKTicket.confirmEndOfChat(with: message, confirm: confirmed) { (ticker, error) in
             if let error = error {
@@ -59,6 +63,9 @@ extension ChatViewController: DeskChannelModuleListDelegate {
 protocol DeskChannelModuleListDelegate: SBUGroupChannelModuleListDelegate {
     func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, didSelectQuestion question: String, forID faqFileID: Int64)
     
+    /// Called when it needs to present alert controller to answer the inquire message for ticket closing.
+    ///
+    /// See `deskChannelModule(_:shouldPresentReplyOptionsForInquireMessage:)` and `sendConfirmation(_:toInquireMessage:)` in `ChatViewController`
     func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldPresentReplyOptionsForInquireMessage message: UserMessage)
 }
 

--- a/QuickStart/ChatViewController.swift
+++ b/QuickStart/ChatViewController.swift
@@ -28,17 +28,17 @@ extension ChatViewController: DeskChannelModuleListDelegate {
         }
     }
     
-    func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldPresentReplyOptionsForInquireMessage message: UserMessage) {
-        let confirmAction = UIAlertAction(title: "Yes", style: .default) { [weak self, message] _ in
+    func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldAskConfirmationOf ticketClosingMessage: UserMessage) {
+        let confirmAction = UIAlertAction(title: "Yes", style: .default) { [weak self, ticketClosingMessage] _ in
             guard let self = self else { return }
-            self.sendConfirmation(true, toInquireMessage: message)
+            self.sendConfirmation(true, ofTicketClosing: ticketClosingMessage)
         }
-        let declineAction = UIAlertAction(title: "No", style: .default) { [weak self, message] _ in
+        let declineAction = UIAlertAction(title: "No", style: .default) { [weak self, ticketClosingMessage] _ in
             guard let self = self else { return }
-            self.sendConfirmation(false, toInquireMessage: message)
+            self.sendConfirmation(false, ofTicketClosing: ticketClosingMessage)
             
         }
-        let alertController = UIAlertController(title: message.message, message: nil, preferredStyle: .alert)
+        let alertController = UIAlertController(title: ticketClosingMessage.message, message: nil, preferredStyle: .alert)
         alertController.addAction(confirmAction)
         alertController.addAction(declineAction)
         self.present(alertController, animated: true)
@@ -49,7 +49,7 @@ extension ChatViewController: DeskChannelModuleListDelegate {
     /// When `confirmed` is true, it sends user message with the text saying "Yes". If it's `false`, sends the text saying "No".
     ///
     /// - NOTE: [Documentations | Send confirmation of ticket closing]( https://sendbird.com/docs/desk/sdk/v1/ios/features/confirmation-request#2-send-confirmation-of-ticket-closing)
-    func sendConfirmation(_ confirmed: Bool, toInquireMessage message: UserMessage) {
+    func sendConfirmation(_ confirmed: Bool, ofTicketClosing message: UserMessage) {
         SBDSKTicket.confirmEndOfChat(with: message, confirm: confirmed) { (ticker, error) in
             if let error = error {
                 print(error.localizedDescription)
@@ -63,10 +63,10 @@ extension ChatViewController: DeskChannelModuleListDelegate {
 protocol DeskChannelModuleListDelegate: SBUGroupChannelModuleListDelegate {
     func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, didSelectQuestion question: String, forID faqFileID: Int64)
     
-    /// Called when it needs to present alert controller to answer the inquire message for ticket closing.
+    /// Called when it needs to ask the confirmation of ticket closing message.
     ///
     /// See `deskChannelModule(_:shouldPresentReplyOptionsForInquireMessage:)` and `sendConfirmation(_:toInquireMessage:)` in `ChatViewController`
-    func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldPresentReplyOptionsForInquireMessage message: UserMessage)
+    func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldAskConfirmationOf ticketClosingMessage: UserMessage)
 }
 
 class DeskChannelModule {
@@ -120,7 +120,7 @@ class DeskChannelModule {
             // When the message is inquire ticket closure
             else if let userMessage = message as? UserMessage, userMessage.data.contains("\"type\":\"SENDBIRD_DESK_INQUIRE_TICKET_CLOSURE\""), userMessage.data.contains("\"state\":\"WAITING\"") {
                 (self.delegate as? DeskChannelModuleListDelegate)?
-                    .deskChannelModule(self, shouldPresentReplyOptionsForInquireMessage: userMessage)
+                    .deskChannelModule(self, shouldAskConfirmationOf: userMessage)
                 
                 return super.tableView(tableView, cellForRowAt: indexPath)
             }

--- a/QuickStart/ChatViewController.swift
+++ b/QuickStart/ChatViewController.swift
@@ -48,7 +48,7 @@ extension ChatViewController: DeskChannelModuleListDelegate {
     ///
     /// When `confirmed` is true, it sends user message with the text saying "Yes". If it's `false`, sends the text saying "No".
     ///
-    /// - NOTE: [Documentations | Send confirmation of ticket closing]( https://sendbird.com/docs/desk/sdk/v1/ios/features/confirmation-request#2-send-confirmation-of-ticket-closing)
+    /// - NOTE: [Documentations | Send confirmation of ticket closing](https://sendbird.com/docs/desk/sdk/v1/ios/features/confirmation-request#2-send-confirmation-of-ticket-closing)
     func sendConfirmation(_ confirmed: Bool, ofTicketClosing message: UserMessage) {
         SBDSKTicket.confirmEndOfChat(with: message, confirm: confirmed) { (ticker, error) in
             if let error = error {

--- a/QuickStart/ChatViewController.swift
+++ b/QuickStart/ChatViewController.swift
@@ -25,9 +25,8 @@ class ChatViewController: SBUGroupChannelViewController {
             userMessage.data.contains("\"type\":\"SENDBIRD_DESK_INQUIRE_TICKET_CLOSURE\""),
             userMessage.data.contains("\"state\":\"WAITING\"") {
             self.presentConfirmationAlert(of: userMessage)
-        } else {
-            super.baseChannelViewModel(viewModel, didReceiveNewMessage: message, forChannel: channel)
         }
+        super.baseChannelViewModel(viewModel, didReceiveNewMessage: message, forChannel: channel)
     }
     
     /// Presents alert controller to ask the confirmation of ticket closing.


### PR DESCRIPTION
## Screenshot

| When received the request for ticket closing | After sending confirmation |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-22 at 12 47 00](https://github.com/sendbird/quickstart-desk-ios/assets/53814741/7da5057d-49bb-41b0-a9db-280f291e66f7) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-22 at 12 47 09](https://github.com/sendbird/quickstart-desk-ios/assets/53814741/84f20704-cfbd-4beb-ae0f-e284829be45e) |


## Background

When the agent made request for closing the ticket, it sends message with the following data below:

| key | value |
| --- | --- |
| type | `SENDBIRD_DESK_INQUIRE_TICKET_CLOSURE` |
| state | `WAITING` |

The sample should answer the request by using `SBDSKTicket.confirmEndOfChat(with:confirm:completionHandler:)`

## What's changed

1. when `DeskChannelModule.List` draws the inquire message, it calls `deskChannelModule(_:shouldAskConfirmationOf:)` in `DeskChannelModuleListDelegate`
    ```swift
    // DeskChannelModule.List
    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        // When the message is inquire ticket closure
        else if let userMessage = message as? UserMessage, userMessage.data.contains("\"type\":\"SENDBIRD_DESK_INQUIRE_TICKET_CLOSURE\""), userMessage.data.contains("\"state\":\"WAITING\"") {
            delegate?.deskChannelModule(self, shouldAskConfirmationOf: userMessage)
                
            return super.tableView(tableView, cellForRowAt: indexPath)
        }
    }
    ```
2. The delegate event is called in `ChatViewController`
3. `ChatViewController` presents `UIAlertController` and each alert action will invoke 
`sendConfirmation(_:ofTicketClosing:)` method.
    ```swift
    // ChatViewController
    func deskChannelModule(_ listComponent: SBUGroupChannelModule.List, shouldAskConfirmationOf ticketClosingMessage: UserMessage) {
        let confirmAction = UIAlertAction(title: "Yes", style: .default) { _ in
            self.sendConfirmation(true, ofTicketClosing: ticketClosingMessage)
        }
        let declineAction = UIAlertAction(title: "No", style: .default) { _ in
            self.sendConfirmation(false, ofTicketClosing: ticketClosingMessage)
        }

        // Creates the new `UIAlertController` and adds actions ...

        self.present(alertController, animated: true)
    }
    ```
4. `sendConfirmation(_:ofTicketClosing:)` method calls `SBDSKTicket.confirmEndOfChat(with:confirm:completionHandler:)`
    ```swift
    // ChatViewController
    func sendConfirmation(_ confirmed: Bool, ofTicketClosing message: UserMessage) {
        SBDSKTicket.confirmEndOfChat(with: message, confirm: confirmed) { (ticker, error) in
            // handler error...

            self.viewModel?.sendUserMessage(text: confirmed ? "Yes" : "No")
        }
    }
    ```

