### PR TITLE
[FIX: Send confirmation of ticket closing] Change delegate method from `didReceiveMessages` to `didChangeMessages`

### DIFF
--- a/QuickStart/ChatViewController.swift
+++ b/QuickStart/ChatViewController.swift
@@ -45,15 +45,14 @@ class ChatViewController: SBUGroupChannelViewController {
     }
   
     // MARK: - Send confirmation of ticket closing
-    
-    override func baseChannelViewModel(_ viewModel: SBUBaseChannelViewModel, didReceiveNewMessage message: BaseMessage, forChannel channel: BaseChannel) {
-    // When the message is inquire ticket closure
-        if let userMessage = message as? UserMessage,
+    override func baseChannelViewModel(_ viewModel: SBUBaseChannelViewModel, didChangeMessageList messages: [BaseMessage], needsToReload: Bool, initialLoad: Bool) {
+        // When the message is inquire ticket closure
+        if let userMessage = messages.first as? UserMessage,
             userMessage.data.contains("\"type\":\"SENDBIRD_DESK_INQUIRE_TICKET_CLOSURE\""),
             userMessage.data.contains("\"state\":\"WAITING\"") {
             self.presentConfirmationAlert(of: userMessage)
         }
-        super.baseChannelViewModel(viewModel, didReceiveNewMessage: message, forChannel: channel)
+        super.baseChannelViewModel(viewModel, didChangeMessageList: messages, needsToReload: needsToReload, initialLoad: initialLoad)
     }
     
     /// Presents alert controller to ask the confirmation of ticket closing.


### PR DESCRIPTION
Fix feature: https://github.com/sendbird/quickstart-desk-ios/pull/14

| Before | Inquire | Reply |
| --- | --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-08-30 at 23 10 31](https://github.com/sendbird/quickstart-desk-ios/assets/53814741/bf7cf459-9dde-4feb-b592-fa19555de095) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-08-30 at 23 10 52](https://github.com/sendbird/quickstart-desk-ios/assets/53814741/0db50874-f5da-4e8d-b3af-0989e2790970) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-08-30 at 23 10 56](https://github.com/sendbird/quickstart-desk-ios/assets/53814741/a6c38d87-096c-44a1-8f8d-9ecaad9a911c)

[CLNP-576]: https://sendbird.atlassian.net/browse/CLNP-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ